### PR TITLE
add: fullDigital management

### DIFF
--- a/docs/openapi/schemas-paper-v2.yaml
+++ b/docs/openapi/schemas-paper-v2.yaml
@@ -726,6 +726,13 @@ components:
                   La descrizione della tipologia di oggetto.
                 minItems: 2
                 maxItems: 10
+              originType:
+                type: string
+                description: >-
+                  Indica se il documento è stato prodotto tramite scansione cartacea (`SCANNED`) oppure generato digitalmente (`DIGITAL`). 
+                  - __SCANNED__ <br/>
+                  - __DIGITAL__ <br/>
+                  In caso di assenza del campo, la piattaforma considererà DIGITAL gli allegati con MIME/Type application/zip.
               documentId:
                 type: string
                 description: >-


### PR DESCRIPTION
This PR introduces the following changes to the schemas and OpenAPI specifications:

Updated the description of attachments to clearly distinguish between documents produced by paper scanning (SCANNED) and those digitally generated (GENERATED), through the new _originType_ field.

To ensure backward compatibility with what is currently in production, the _originType_ field is optional. Only attachments with MIME type application/zip will be treated as digital if the field is not provided.


